### PR TITLE
Fix DropZone error handling

### DIFF
--- a/frontend/src/components/DropZone.svelte
+++ b/frontend/src/components/DropZone.svelte
@@ -33,10 +33,13 @@
     } catch (err) {
       console.error('Error selecting folder:', err);
       console.error('Error type:', typeof err);
-      console.error('Error name:', err?.name);
-      console.error('Error message:', err?.message);
-      console.error('Error stack:', err?.stack);
-      console.error('Error details:', JSON.stringify(err, null, 2));
+
+      if (err instanceof Error) {
+        console.error('Error name:', err.name);
+        console.error('Error message:', err.message);
+        console.error('Error stack:', err.stack);
+      }
+
       showSuccessMessage('An error occurred while selecting folder', false);
     }
   }


### PR DESCRIPTION
## Summary
- better handle errors in the DropZone component

## Testing
- `npm run build`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6877e5b81e708323a5680a5aa365d86a