### PR TITLE
Fix frontend error logging type issues

### DIFF
--- a/frontend/src/components/DropZone.svelte
+++ b/frontend/src/components/DropZone.svelte
@@ -32,11 +32,12 @@
       showSuccessMessage('Folder selected successfully!', true);
     } catch (err) {
       console.error('Error selecting folder:', err);
-      console.error('Error type:', typeof err);
-      console.error('Error name:', err?.name);
-      console.error('Error message:', err?.message);
-      console.error('Error stack:', err?.stack);
-      console.error('Error details:', JSON.stringify(err, null, 2));
+      if (err instanceof Error) {
+        console.error('Error type:', typeof err);
+        console.error('Error name:', err.name);
+        console.error('Error message:', err.message);
+        console.error('Error stack:', err.stack);
+      }
       showSuccessMessage('An error occurred while selecting folder', false);
     }
   }
@@ -62,6 +63,12 @@
       showSuccessMessage(`${files.length} file(s) selected!`, false);
     } catch (err) {
       console.error('Error selecting files:', err);
+      if (err instanceof Error) {
+        console.error('Error type:', typeof err);
+        console.error('Error name:', err.name);
+        console.error('Error message:', err.message);
+        console.error('Error stack:', err.stack);
+      }
       showSuccessMessage('An error occurred while selecting files', false);
     }
   }


### PR DESCRIPTION
## Summary
- clean up TypeScript error handling in DropZone component
- run `npm run check` & `npm run build`

## Testing
- `npm run check`
- `npm run build`
- `pip install -r requirements.txt` *(fails: heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877e6f08dc0832393ca7ed9938d397a